### PR TITLE
Implemented feature that makes service call details available to a 'prepare request' script

### DIFF
--- a/src/main/resources/elements/service-call/template.hbs
+++ b/src/main/resources/elements/service-call/template.hbs
@@ -72,7 +72,7 @@
         <removeProperty name="serviceCallParametersJson"/>
     {{/if-property}}
 
-    {{#if-property 'integrationOperationProtocolType' equals='ampq'}}
+    {{#if-property 'integrationOperationProtocolType' equals='amqp'}}
         <setProperty name="serviceCallMethod">
             <simple>{{property "integrationOperationMethod"}}</simple>
         </setProperty>

--- a/src/main/resources/elements/service-call/template.hbs
+++ b/src/main/resources/elements/service-call/template.hbs
@@ -12,6 +12,137 @@
 {{/if-property}}
 
 <step id="{{identifier}}">
+
+    {{#if-property 'integrationOperationProtocolType' equals='http'}}
+        <setProperty name="serviceCallAddress">
+            <simple>{{integrationAddress}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallUrl">
+            <simple>{{integrationAddress}}{{escape (integeratePathAndQueryParams)}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallMethod">
+            <simple>{{property "integrationOperationMethod"}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallPath">
+            <simple>{{property "integrationOperationPath"}}</simple>
+        </setProperty>
+
+        <setProperty name="serviceCallQueryParametersJson">
+            <simple>{{property-json "integrationOperationQueryParameters"}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallQueryParameters">
+            <jq resultType="java.util.Map" source="property:serviceCallQueryParametersJson">.</jq>
+        </setProperty>
+        <removeProperty name="serviceCallQueryParametersJson"/>
+
+        <setProperty name="serviceCallPathParametersJson">
+            <simple>{{property-json "integrationOperationPathParameters"}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallPathParameters">
+            <jq resultType="java.util.Map" source="property:serviceCallPathParametersJson">.</jq>
+        </setProperty>
+        <removeProperty name="serviceCallPathParametersJson"/>
+
+        <setProperty name="serviceCallParametersJson">
+            <simple>{{environmentPropertiesJson}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallParameters">
+            <jq resultType="java.util.Map" source="property:serviceCallParametersJson">.</jq>
+        </setProperty>
+        <removeProperty name="serviceCallParametersJson"/>
+    {{/if-property}}
+
+    {{#if-property 'integrationOperationProtocolType' equals='kafka'}}
+        <setProperty name="serviceCallMethod">
+            <simple>{{property "integrationOperationMethod"}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallTopic">
+            <simple>{{property 'integrationOperationPath'}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallBrokers">
+            <simple>{{integrationAddress}}</simple>
+        </setProperty>
+
+        <setProperty name="serviceCallParametersJson">
+            <simple>{{asyncPropertiesJson}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallParameters">
+            <jq resultType="java.util.Map" source="property:serviceCallParametersJson">.</jq>
+        </setProperty>
+        <removeProperty name="serviceCallParametersJson"/>
+    {{/if-property}}
+
+    {{#if-property 'integrationOperationProtocolType' equals='ampq'}}
+        <setProperty name="serviceCallMethod">
+            <simple>{{property "integrationOperationMethod"}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallExchange">
+            <simple>{{property 'integrationOperationPath'}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallAddress">
+            <simple>{{integrationAddress}}</simple>
+        </setProperty>
+
+        <setProperty name="serviceCallParametersJson">
+            <simple>{{asyncPropertiesJson}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallParameters">
+            <jq resultType="java.util.Map" source="property:serviceCallParametersJson">.</jq>
+        </setProperty>
+        <removeProperty name="serviceCallParametersJson"/>
+    {{/if-property}}
+
+    {{#if-property 'integrationOperationProtocolType' equals='grpc'}}
+        <setProperty name="serviceCallMethod">
+            <simple>{{property "integrationOperationMethod"}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallService">
+            <simple>{{property 'integrationOperationPath'}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallAddress">
+            <simple>{{integrationAddress}}</simple>
+        </setProperty>
+
+        <setProperty name="serviceCallParametersJson">
+            <simple>{{grpcPropertiesJson}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallParameters">
+            <jq resultType="java.util.Map" source="property:serviceCallParametersJson">.</jq>
+        </setProperty>
+        <removeProperty name="serviceCallParametersJson"/>
+    {{/if-property}}
+
+    {{#if-property 'integrationOperationProtocolType' equals='graphql'}}
+        <setProperty name="serviceCallAddress">
+            <simple>{{integrationAddress}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallMethod">
+            <simple>{{property "integrationOperationMethod"}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallPath">
+            <simple>{{property "integrationOperationPath"}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallVariablesHeader">
+            <simple>{{property 'integrationGqlVariablesHeader'}}</simple>
+        </setProperty>
+
+        <setProperty name="serviceCallQueryParametersJson">
+            <simple>{{property-json "integrationOperationQueryParameters"}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallQueryParameters">
+            <jq resultType="java.util.Map" source="property:serviceCallQueryParametersJson">.</jq>
+        </setProperty>
+        <removeProperty name="serviceCallQueryParametersJson"/>
+
+        <setProperty name="serviceCallParametersJson">
+            <simple>{{environmentPropertiesJson}}</simple>
+        </setProperty>
+        <setProperty name="serviceCallParameters">
+            <jq resultType="java.util.Map" source="property:serviceCallParametersJson">.</jq>
+        </setProperty>
+        <removeProperty name="serviceCallParametersJson"/>
+    {{/if-property}}
+
     <removeHeader name="CamelHttpQuery"/>
     {{#if-property 'before' presented=''}}
         <step id="Prepare request--{{identifier}}">
@@ -445,4 +576,18 @@
         </choice>
     {{/if-property}}
 </step>
+
 <removeHeader name="CamelHttpUri"/>
+
+<removeProperty name="serviceCallAddress"/>
+<removeProperty name="serviceCallUrl"/>
+<removeProperty name="serviceCallMethod"/>
+<removeProperty name="serviceCallPath"/>
+<removeProperty name="serviceCallQueryParameters"/>
+<removeProperty name="serviceCallPathParameters"/>
+<removeProperty name="serviceCallParameters"/>
+<removeProperty name="serviceCallTopic"/>
+<removeProperty name="serviceCallBrokers"/>
+<removeProperty name="serviceCallExchange"/>
+<removeProperty name="serviceCallService"/>
+<removeProperty name="serviceCallVariablesHeader"/>

--- a/src/main/resources/elements/service-call/template.hbs
+++ b/src/main/resources/elements/service-call/template.hbs
@@ -60,7 +60,7 @@
             <simple>{{property 'integrationOperationPath'}}</simple>
         </setProperty>
         <setProperty name="serviceCallBrokers">
-            <simple>{{integrationAddress}}</simple>
+            <simple>{{integrationEndpoint}}</simple>
         </setProperty>
 
         <setProperty name="serviceCallParametersJson">
@@ -100,7 +100,7 @@
             <simple>{{property 'integrationOperationPath'}}</simple>
         </setProperty>
         <setProperty name="serviceCallAddress">
-            <simple>{{integrationAddress}}</simple>
+            <simple>{{integrationEndpoint}}</simple>
         </setProperty>
 
         <setProperty name="serviceCallParametersJson">


### PR DESCRIPTION
Added the following properties to the exchange for Service Call:

* HTTP
  * serviceCallAddress - address part of an URL, resolved from service environment
  * serviceCallUrl - fully constructed URL for HTTP call
  * serviceCallMethod - HTTP mehod
  * serviceCallPath - path for operation with path parameters placeholders
  * serviceCallQueryParameters - map of query parameters (instance of java.util.Map)
  * serviceCallPathParameters - map of path parameters (instance of java.util.Map)
  * serviceCallPathParameters - map of additional parameters (instance of java.util.Map)
* Kafka
  * serviceCallMethod - AsyncAPI operation method
  * serviceCallTopic - Kafka topic name
  * serviceCallBrokers - Kafka brokers
  * serviceCallParameters - map of additional parameters (instance of java.util.Map)
* AMQP
  * serviceCallMethod - AsyncAPI operation method
  * serviceCallExchange - exchange name
  * serviceCallAddress - server addresses
  * serviceCallParameters - map of additional parameters (instance of java.util.Map)
* gRPC
  * serviceCallMethod - service method to call
  * serviceCallService - service name
  * serviceCallAddress - server address
  * serviceCallParameters - map of additional parameters (instance of java.util.Map)
* GraphQL
  * serviceCallAddress - server address
  * serviceCallMethod - HTTP method
  * serviceCallPath - operation path
  * serviceCallQueryParameters - map of query parameters (instance of java.util.Map)
  * serviceCallParameters - map of additional parameters (instance of java.util.Map)


closes #12 