### PR TITLE
#80 Implement a new mechanism to define main wsdl specification file

### DIFF
--- a/src/main/java/org/qubership/integration/platform/catalog/service/exportimport/ExportImportConstants.java
+++ b/src/main/java/org/qubership/integration/platform/catalog/service/exportimport/ExportImportConstants.java
@@ -68,6 +68,8 @@ public class ExportImportConstants {
     public static final String DIFFERENT_PROTOCOL_ERROR_MESSAGE = "Protocol of provided specification doesn't match with a system protocol";
     public static final String INVALID_INPUT_FILE_ERROR_MESSAGE = "Input file is invalid";
     public static final String NO_SPECIFICATION_SOURCE_ERROR_MESSAGE = "Can't find specification source";
+    public static final String NO_MAIN_SOURCE_ERROR_MESSAGE = "Can't find Main specification source";
+    public static final String MULTIPLE_MAIN_SOURCES_ERROR_MESSAGE = "Multiple Main specification sources found";
     public static final String FILE_CREATION_ERROR_MESSAGE = "Unknown exception during file creation: ";
     public static final String DDL_SCRIPT_FILE_NAME = "ddlScriptFileName";
     public static final String ARCH_PARENT_DIR = "services";

--- a/src/main/java/org/qubership/integration/platform/catalog/service/exportimport/SpecificationImportService.java
+++ b/src/main/java/org/qubership/integration/platform/catalog/service/exportimport/SpecificationImportService.java
@@ -243,7 +243,7 @@ public class SpecificationImportService {
 
     /**
      * Checks whether the given WSDL content represents a main source by verifying the presence
-     * of both <binding> and <service> elements.
+     * of both {@literal <binding>} and {@literal <service>} elements.
      *
      * @param content the byte array of the WSDL file content
      * @return true if both binding and service tags are found; false otherwise

--- a/src/main/java/org/qubership/integration/platform/catalog/service/exportimport/SpecificationImportService.java
+++ b/src/main/java/org/qubership/integration/platform/catalog/service/exportimport/SpecificationImportService.java
@@ -25,7 +25,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.qubership.integration.platform.catalog.context.RequestIdContext;
-import org.qubership.integration.platform.catalog.exception.*;
+import org.qubership.integration.platform.catalog.exception.CatalogRuntimeException;
+import org.qubership.integration.platform.catalog.exception.SpecificationImportException;
+import org.qubership.integration.platform.catalog.exception.SpecificationImportWarningException;
+import org.qubership.integration.platform.catalog.exception.SpecificationSimilarVersionException;
 import org.qubership.integration.platform.catalog.model.system.OperationProtocol;
 import org.qubership.integration.platform.catalog.persistence.configs.entity.ConfigParameter;
 import org.qubership.integration.platform.catalog.persistence.configs.entity.system.IntegrationSystem;
@@ -37,6 +40,7 @@ import org.qubership.integration.platform.catalog.service.ConfigParameterService
 import org.qubership.integration.platform.catalog.service.SystemBaseService;
 import org.qubership.integration.platform.catalog.service.SystemModelBaseService;
 import org.qubership.integration.platform.catalog.service.parsers.OperationParserService;
+import org.qubership.integration.platform.catalog.service.resolvers.wsdl.WsdlRootFileParser;
 import org.qubership.integration.platform.catalog.util.MultipartFileUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -73,6 +77,7 @@ public class SpecificationImportService {
     private final ObjectMapper objectMapper;
     private final SystemBaseService systemBaseService;
     private final SystemModelBaseService systemModelService;
+    private final WsdlRootFileParser wsdlRootFileParser;
 
     @Autowired
     public SpecificationImportService(OperationParserService operationParserService,
@@ -82,7 +87,8 @@ public class SpecificationImportService {
                                       ProtocolExtractionService protocolExtractionService,
                                       @Qualifier("primaryObjectMapper") ObjectMapper objectMapper,
                                       SystemBaseService systemBaseService,
-                                      SystemModelBaseService systemModelService
+                                      SystemModelBaseService systemModelService,
+                                      WsdlRootFileParser wsdlRootFileParser
     ) {
         this.operationParserService = operationParserService;
         this.specificationGroupRepository = specificationGroupRepository;
@@ -92,6 +98,7 @@ public class SpecificationImportService {
         this.objectMapper = objectMapper;
         this.systemBaseService = systemBaseService;
         this.systemModelService = systemModelService;
+        this.wsdlRootFileParser = wsdlRootFileParser;
     }
 
     @AllArgsConstructor
@@ -221,14 +228,29 @@ public class SpecificationImportService {
         }
     }
 
-    private boolean isMainSpecificationSource(OperationProtocol protocol, MultipartFile file) {
-        return (OperationProtocol.SOAP.equals(protocol) && WSDL_EXTENSION_PATTERN.matcher(file.getOriginalFilename()).matches())
+    private boolean isMainSpecificationSource(OperationProtocol protocol, MultipartFile file) throws IOException {
+        return (OperationProtocol.SOAP.equals(protocol)
+                && WSDL_EXTENSION_PATTERN.matcher(String.valueOf(file.getOriginalFilename())).matches()
+                && isMainSource(file.getBytes())
+        )
                 || (List.of(
                 OperationProtocol.HTTP,
                 OperationProtocol.AMQP,
                 OperationProtocol.GRAPHQL,
                 OperationProtocol.KAFKA
         ).contains(protocol));
+    }
+
+    /**
+     * Checks whether the given WSDL content represents a main source by verifying the presence
+     * of both <binding> and <service> elements.
+     *
+     * @param content the byte array of the WSDL file content
+     * @return true if both binding and service tags are found; false otherwise
+     */
+    private boolean isMainSource(byte[] content) {
+        String wsdlString = new String(content);
+        return wsdlRootFileParser.checkRootFile(wsdlString);
     }
 
     private List<SpecificationSource> getSpecificationSources(
@@ -247,8 +269,11 @@ public class SpecificationImportService {
                 throw new SpecificationImportException(ExportImportConstants.INVALID_INPUT_FILE_ERROR_MESSAGE, exception);
             }
         }).collect(Collectors.toList());
-        boolean mainSourceIsNotSpecified = specificationSources.stream().noneMatch(SpecificationSource::isMainSource);
-        if (!specificationSources.isEmpty() && mainSourceIsNotSpecified) {
+        long mainSourceCount = specificationSources.stream().filter(SpecificationSource::isMainSource).count();
+        if (mainSourceCount > 1) {
+            log.error(ExportImportConstants.MULTIPLE_MAIN_SOURCES_ERROR_MESSAGE);
+        } else if (mainSourceCount == 0) {
+            log.error(ExportImportConstants.NO_MAIN_SOURCE_ERROR_MESSAGE);
             specificationSources.get(0).setMainSource(true);
         }
         specificationSourceRepository.saveAll(specificationSources);

--- a/src/main/java/org/qubership/integration/platform/catalog/service/parsers/impl/WSDLSpecificationParser.java
+++ b/src/main/java/org/qubership/integration/platform/catalog/service/parsers/impl/WSDLSpecificationParser.java
@@ -60,7 +60,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.*;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -139,9 +138,23 @@ public class WSDLSpecificationParser implements SpecificationParser {
     ) throws SpecificationImportException {
         SpecificationSource mainSource = getMainSource(sources);
         WsdlVersion wsdlVersion = wsdlVersionParser.getWSDLVersion(mainSource.getSource());
-        return getOperationListBuilder(wsdlVersion).apply(specificationGroup, sources);
+        if (WsdlVersion.WSDL_2.equals(wsdlVersion)) {
+            return extractOperationsFromWsdlV2(specificationGroup, sources, mainSource);
+        } else {
+            return extractOperationsFromWsdlV1(specificationGroup, sources, mainSource);
+        }
     }
 
+    /**
+     * Retrieves the main WSDL specification source from the provided collection.
+     * <p>
+     * This method filters the collection for sources explicitly marked as the main source
+     * using {@code isMainSource()}. If no such source is found, an exception is thrown.
+     *
+     * @param sources the collection of WSDL specification sources to evaluate
+     * @return the main {@link SpecificationSource} marked as primary
+     * @throws SpecificationImportException if no main source could be determined
+     */
     private SpecificationSource getMainSource(Collection<SpecificationSource> sources) {
         return sources.stream()
                 .filter(SpecificationSource::isMainSource)
@@ -149,13 +162,10 @@ public class WSDLSpecificationParser implements SpecificationParser {
                 .orElseThrow(() -> new SpecificationImportException("Couldn't determine main specification source"));
     }
 
-    private BiFunction<SpecificationGroup, Collection<SpecificationSource>, List<Operation>> getOperationListBuilder(WsdlVersion version) {
-        return WsdlVersion.WSDL_2.equals(version) ? this::extractOperationsFromWsdlV2 : this::extractOperationsFromWsdlV1;
-    }
-
     private List<Operation> extractOperationsFromWsdlV2(
             SpecificationGroup specificationGroup,
-            Collection<SpecificationSource> sources
+            Collection<SpecificationSource> sources,
+            SpecificationSource mainSource
     ) {
         try {
             Map<SpecificationSource, String> sourceFileMap = sources.stream().collect(Collectors.toMap(
@@ -182,7 +192,6 @@ public class WSDLSpecificationParser implements SpecificationParser {
                             return null;
                         }
                     }).orElse(simpleURIResolver.resolveURI(uri)));
-            SpecificationSource mainSource = getMainSource(sources);
             DescriptionElement descElem = (DescriptionElement) reader.readWSDL(sourceFileMap.get(mainSource));
             Description description = descElem.toComponent();
             setUpWoodenEnvironment(specificationGroup, description);
@@ -197,11 +206,10 @@ public class WSDLSpecificationParser implements SpecificationParser {
 
     private List<Operation> extractOperationsFromWsdlV1(
             SpecificationGroup specificationGroup,
-            Collection<SpecificationSource> sources
+            Collection<SpecificationSource> sources,
+            SpecificationSource mainSource
     ) {
         try {
-            SpecificationSource mainSource = getMainSource(sources);
-
             WSDLParser parser = new WSDLParser();
             parser.setResourceResolver(buildResourceResolver(sources));
 

--- a/src/main/java/org/qubership/integration/platform/catalog/service/resolvers/wsdl/WsdlRootFileParser.java
+++ b/src/main/java/org/qubership/integration/platform/catalog/service/resolvers/wsdl/WsdlRootFileParser.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.catalog.service.resolvers.wsdl;
+
+import org.qubership.integration.platform.catalog.exception.SpecificationImportException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.StringReader;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+@Service
+@Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
+public class WsdlRootFileParser {
+    public static final String INVALID_WSDL_FILE_EXCEPTION = "Error during parsing WSDL structure: ";
+    public static final String VERSION_PARSER_CONFIGURE_ERROR_MESSAGE = "Error during version's parser configure: ";
+
+    private final SAXParserFactory saxParserFactory;
+
+    @Autowired
+    public WsdlRootFileParser(
+            @Qualifier("wsdlVersionSaxParserFactory") SAXParserFactory saxParserFactory
+    ) {
+        saxParserFactory.setNamespaceAware(true);
+        this.saxParserFactory = saxParserFactory;
+    }
+
+    public boolean checkRootFile(String documentText) {
+        try {
+            InputSource specificationInputSource = new InputSource(new StringReader(documentText));
+            SAXParser parser = this.saxParserFactory.newSAXParser();
+            WsdlRootFileParserHandler wsdlRootFileParserHandler = new WsdlRootFileParserHandler();
+            parser.parse(specificationInputSource, wsdlRootFileParserHandler);
+            return wsdlRootFileParserHandler.isRootCandidate();
+        } catch (SAXException | IOException e) {
+            throw new SpecificationImportException(INVALID_WSDL_FILE_EXCEPTION, e.getCause());
+        } catch (ParserConfigurationException e) {
+            throw new SpecificationImportException(VERSION_PARSER_CONFIGURE_ERROR_MESSAGE, e.getCause());
+        }
+    }
+}

--- a/src/main/java/org/qubership/integration/platform/catalog/service/resolvers/wsdl/WsdlRootFileParserHandler.java
+++ b/src/main/java/org/qubership/integration/platform/catalog/service/resolvers/wsdl/WsdlRootFileParserHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.catalog.service.resolvers.wsdl;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.util.Set;
+
+public class WsdlRootFileParserHandler extends DefaultHandler {
+
+    private static final Set<String> WSDL_NAMESPACES = Set.of(
+            "http://schemas.xmlsoap.org/wsdl/", // WSDL 1.1
+            "http://www.w3.org/ns/wsdl"         // WSDL 2.0
+    );
+
+    private boolean hasService = false;
+    private boolean hasBinding = false;
+
+    @Override
+    public void startElement(String uri, String lName, String qName, Attributes attr) {
+        if (WSDL_NAMESPACES.contains(uri)) {
+            if ("service".equals(lName)) {
+                hasService = true;
+            } else if ("binding".equals(lName)) {
+                hasBinding = true;
+            }
+        }
+    }
+
+    public boolean isRootCandidate() {
+        return hasService && hasBinding;
+    }
+}


### PR DESCRIPTION
Implemented logic to identify main wsdl specification file through finding "service" and "binding" sections inside it. The sax parser is used for this.

Close #80 