### PR TITLE
chore(ci): update of CLA workflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -7,13 +7,28 @@ on:
     types: [opened, closed, synchronize]
 
 permissions:
-  actions: write
   contents: read
-  pull-requests: write
-  statuses: write
 
 jobs:
-  cla_assistant:
-    uses: Netcracker/qubership-workflow-hub/.github/workflows/cla.yaml@main
-    secrets:
-      personal_access_token: ${{ secrets.CLA_ACCESS_TOKEN }}
+  CLAAssistant:
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 #v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/Netcracker/qubership-github-workflows/blob/main/CLA/cla.md'
+          # branch should not be protected
+          branch: 'main'
+          allowlist: NetcrackerCLPLCI,web-flow,bot*
+          remote-repository-name: cla-storage
+          remote-organization-name: Netcracker


### PR DESCRIPTION
Pinned `contributor-assistant/github-action` version to v2.6.1 SHA